### PR TITLE
OpenMPI 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # tmpi
 Run a parallel command inside a split tmux window
-
-Forked from https://github.com/moben/scripts/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp tmpi /usr/local/bin

--- a/tmpi
+++ b/tmpi
@@ -61,7 +61,7 @@ if [[ ${1} == runmpi ]] ; then
     done
 
     # get all the variables that mpirun starts us with so that we can pass them through.
-    mpi_vars=( $( env | grep -e MPI -e OPAL | cut -d '=' -f1 ) )
+    mpi_vars=( $( env | grep -e MPI -e OPAL -e PMIX | cut -d '=' -f1 ) )
     mpi_vars+=( "${additional_vars[@]}" )
 
     # add the variables to tmux' session environment.


### PR DESCRIPTION
without this patch, it crashes in some weird way as the MPI ranks don't have all expected env vars at startup

I also temporarily updated the README.md, because there's no trace of ``tmpi`` at that repo anymore. Maybe acknowledge it in some other way? Anyway, feel free to drop ``28a9e0e ``