### PR TITLE
Add support for 'TMPI_TMUX_OPTIONS' environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # tmpi
-Run a parallel command inside a split tmux window
+Run multiple MPI processes as a grid in a new tmux window and multiplex keyboard input to all of them.
+
+## Dependencies
+- [tmux](https://github.com/tmux/tmux/wiki)
+- [OpenMPI](https://www.open-mpi.org/)
+
+## Installation
+Just copy the `tmpi` script somewhere in your `PATH`.
+One-liner:
+```bash
+curl https://raw.githubusercontent.com/Azrael3000/tmpi/master/tmpi -o /somewhere/in/your/path/tmpi
+```
 
 ## Example usage:
 
@@ -7,6 +18,9 @@ Parallel debugging with GDB:
 ```
 tmpi 4 gdb executable
 ```
+
+## Full usage:
+See `usage()` in the [script](tmpi)
 
 ## Contributors:
 * Benedikt Morbach

--- a/tmpi
+++ b/tmpi
@@ -22,6 +22,8 @@ usage() {
     echo 'LD_LIBRARY_PATH="${PWD}/.libs:${LD_LIBRARY_PATH}" tmpi 16 gdb -q bin/.libs/example'
     echo ''
     echo 'The new window is set to remain on exit and has to be closed manually. ("C-b + &" by default)'
+    echo 'You can use the environment variable TMPI_TMUX_OPTIONS to pass options to the `tmux` invocation, '
+    echo '  such as '-f ~/.tmux.conf.tmpi' to use a special tmux configuration for tmpi.
     echo 'Little usage hint: By default the panes in the window are synchronized. If you wish to work only with one thread maximize this pane ("C-b + z" by default) and work away on one thread. Return to all thread using the same shortcut.'
 }
 
@@ -46,7 +48,7 @@ if [[ -z ${TMUX} ]]; then
     # start a new one so that our window doesn't end up in some other session and we have to search it.
     # actually start a new server with '-L' to ensure that our environment carries over.
     socket=$(mktemp --dry-run tmpi.XXXX)
-    exec tmux -L ${socket} new-session "${0} ${*}"
+    exec tmux ${TMPI_TMUX_OPTIONS} -L ${socket} new-session "${0} ${*}"
 fi
 
 if [[ ${1} == runmpi ]] ; then


### PR DESCRIPTION
Allow passing options to the tmux invocation by using an environment
variable, `TMPI_TMUX_OPTIONS`.

This is useful, for example, to use
a separate tmux configuration file with tmpi:

    $ export TMPI_TMUX_OPTIONS='-f ~/.tmux.conf.tmpi'
    $ tmux 4 gdb <executable>

The above would create the new tmux session by loading
`~/.tmux.conf.tmpi` instead of the usual tmux configuration files.


Also, I tweaked the README a little bit.

---

This tool is awesome ! wish I'd known about it earlier! thanks for hosting it :)