### PR TITLE
Use `mktemp -u` rather than `mktemp --dry-run`

### DIFF
--- a/tmpi
+++ b/tmpi
@@ -47,7 +47,7 @@ if [[ -z ${TMUX} ]]; then
     # it seems we aren't in a tmux session.
     # start a new one so that our window doesn't end up in some other session and we have to search it.
     # actually start a new server with '-L' to ensure that our environment carries over.
-    socket=$(mktemp --dry-run tmpi.XXXX)
+    socket=$(mktemp -u tmpi.XXXX)
     exec tmux ${TMPI_TMUX_OPTIONS} -L ${socket} new-session "${0} ${*}"
 fi
 


### PR DESCRIPTION
`mktemp --dry-run` is not supported on Mac OS.

I "tested" `mktemp -u` on one linux machine and it worked. But I'm not sure if this is a general fix.

Feel free to disregard if it doesn't work, but thought I should pass along this tip for using `tmpi` on a Mac...