### PR TITLE
avoid recursive calls, failed with openmpi 2.0.2

### DIFF
--- a/tmpi
+++ b/tmpi
@@ -8,13 +8,15 @@
 mpirun_cmd=${MPIRUN:-mpirun}
 reptyr_cmd=${REPTYR:-reptyr}
 
-mpich=$(${mpirun_cmd} --version |grep -i -e HYDRA -e Intel)
-openmpi=$(${mpirun_cmd} --version |grep -i "Open MPI")
+check_mpirun() {
+    mpich=$(${mpirun_cmd} --version |grep -i -e HYDRA -e Intel)
+    openmpi=$(${mpirun_cmd} --version |grep -i "Open MPI")
 
-if [ -z "${mpich}" ] && [ -z "${openmpi}" ]; then
-    echo "Unknown MPI implementation. Only MPICH (and its derivatives) and OpenMPI are supported!"
-    exit 1
-fi
+    if [ -z "${mpich}" ] && [ -z "${openmpi}" ]; then
+        echo "Unknown MPI implementation. Only MPICH (and its derivatives) and OpenMPI are supported!"
+        exit 1
+    fi
+}
 
 usage() {
     echo 'tmpi: Run multiple MPI processes as a grid in a new tmux window and multiplex keyboard input to all of them.'
@@ -47,6 +49,7 @@ check_tools() {
             fi
         fi
     done
+    check_mpirun
     return 0
 }
 


### PR DESCRIPTION
Hi,

I tried to use your script with our code.
I'm developing in a Singularity container, and this environment embeds a old OpenMPI version 2.0.2.
It doesn't support to be called itself under mpirun (for --version).

This PR proposes to check MPICH/OpenMPI only during the first stage, when `check_tools` is called.

Thank you for this work!
Mathieu